### PR TITLE
Add PCI configuration space abstractions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "crate-template"
+name = "vm-pci"
 version = "0.1.0"
 authors = ["TODO"]
-description = "This is a template for creating rust-vmm repositories."
-repository = "https://github.com/rust-vmm/crate-template"
+description = "Crate for emulating PCI devices in Rust hypervisors."
+repository = "https://github.com/rust-vmm/vm-pci"
 readme = "README.md"
 keywords = ["virt"]
 license = "Apache-2.0 OR BSD-3-Clause"

--- a/README.md
+++ b/README.md
@@ -1,41 +1,97 @@
-# Crate Name
+# vm-pci
 
 ## Design
 
-TODO: This section should have a high-level design of the crate.
+This crate provides an abstraction over a subset of the PCI configuration
+space functionality necessary for emulating a PCI device.
 
-Some questions that might help in writing this section:
-- What is the purpose of this crate?
-- What are the main components of the crate? How do they interact which each
-  other?
+The PCI specification states that every PCI compatible device must provide
+a standardized configuration space of 256 bytes, organized into registers
+of 4 bytes. All devices share the layout of the first 4 registers, defined
+below
+
+```
+bit 31                                             bit 0
+|------------------------------------------------------|
+|        Device ID         |         Vendor ID         |
+|--------------------------+---------------------------|
+|          Status          |         Command           |
+|--------------------------+------------+--------------|
+| Class code | Subclass    |    Prog IF | Revision ID  |
+|------------+-------------+------------+--------------|
+| BIST       | Header Type | Lat Timer  | Cache Line   |
+|--------------------------+---------------------------|
+```
+
+Abstractions for the common PCI configuration space are present in the
+`pci_config` module.
+
+The header type determines what kind of device that is configured and the
+layout of the next 12 registers. Header type 0x00 is for generic PCI
+devices, present in the `device` module. Header type 0x01 is for PCI
+bridges, present in the `bridge` module. Header type 0x02 is for PCI
+Cardbus bridges and is not implemented in this crate.
+
+Though not present right now, the aim of this crate is to provide a
+Host Bridge PCI Bus abstraction which would then be integrated with the
+`Device` and `MutDevice` traits in `vm-device`.
 
 ## Usage
 
-TODO: This section describes how the crate is used.
+Add vm-pci as a dependency in Cargo.toml
 
-Some questions that might help in writing this section:
-- What traits do users need to implement?
-- Does the crate have any default/optional features? What is each feature
-  doing?
-- Is this crate used by other rust-vmm components? If yes, how?
+```toml
+[dependencies]
+vm-pci = "*"
+````
+
+Import the `PciConfig` trait and implement it to emulate a simple host bridge.
+Then import the `PciDeviceConfig` trait and implement it for your devices.
+The device implementations need to be added to a PCI bus, which needs to be
+exposed in the Port IO or MMIO Device Managers in order to be visible in the
+guest. Additionally, you can add any desired PCI capabilities to your devices'
+configuration spaces and emulate them separately.
 
 ## Examples
 
-TODO: Usage examples.
+Basic implementation of a common PCI configuration space.
 
 ```rust
-use my_crate;
+use vm_pci;
 
-...
+struct DummyConfig {
+    registers: [u32; 64],
+}
+
+impl PciConfig for DummyConfig {
+    fn read_register(&self, idx: usize) -> std::result::Result<u32, ConfigSpaceAccessError> {
+        if idx >= 64 {
+            return Err(ConfigSpaceAccessError::OffsetOutOfBounds);
+        }
+        Ok(self.registers[idx])
+    }
+
+    fn write_register(
+        &mut self,
+        data: u32,
+        idx: usize,
+   ) -> std::result::Result<(), ConfigSpaceAccessError> {
+        if idx >= 64 {
+            return Err(ConfigSpaceAccessError::OffsetOutOfBounds);
+        }
+        self.registers[idx] = data;
+        Ok(())
+    }
+}
 ```
+
+The struct above can have further trait implementations (e.g.
+`PciDeviceConfig`) if one needs to access to PCI device functionality, like
+adding and retrieving BARs.
 
 ## License
 
-**!!!NOTICE**: The BSD-3-Clause license is not included in this template.
-The license needs to be manually added because the text of the license file
-also includes the copyright. The copyright can be different for different
-crates. If the crate contains code from CrosVM, the crate must add the
-CrosVM copyright which can be found
-[here](https://chromium.googlesource.com/chromiumos/platform/crosvm/+/master/LICENSE).
-For crates developed from scratch, the copyright is different and depends on
-the contributors.
+This project is licensed under either of
+
+- [Apache License](http://www.apache.org/licenses/LICENSE-2.0), Version 2.0
+- [BSD-3-Clause License](https://opensource.org/licenses/BSD-3-Clause)

--- a/src/bar.rs
+++ b/src/bar.rs
@@ -1,0 +1,205 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt;
+
+use crate::pci_config::{validate_dword_alignment, Error as ConfigSpaceAccessError};
+
+type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug)]
+/// Error type for PCI Base Address Register accesses.
+pub enum Error {
+    /// Invalid access in the configuration space.
+    Access(ConfigSpaceAccessError),
+    /// Memory region defined by the BAR address and lenght is invalid.
+    BarAddressInvalid(u64, u64),
+}
+
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Error::*;
+
+        match self {
+            Access(e) => write!(f, "config space access: {}", e),
+            BarAddressInvalid(addr, len) => {
+                write!(f, "out of bounds BAR addr {} len {}", addr, len)
+            }
+        }
+    }
+}
+
+impl From<ConfigSpaceAccessError> for Error {
+    fn from(e: ConfigSpaceAccessError) -> Self {
+        Error::Access(e)
+    }
+}
+
+#[derive(Copy, Clone)]
+/// Enum representing the "prefetchable" state masks of BARs (bit 3 in the register).
+pub enum PciBarPrefetchable {
+    /// Non-prefetchable BARs have bit 3 set to 0.
+    NotPrefetchable = 0,
+    /// Prefetchable BARs have bit 3 set to 1.
+    Prefetchable = 0x08,
+}
+
+#[derive(Copy, Clone, PartialEq)]
+/// PCI BAR memory region abstraction.
+pub enum PciBarRegion {
+    /// Represents a 32-bit IO space region.
+    Io {
+        /// Start address of the 32-bit IO space region.
+        addr: u32,
+        /// Length of the region, in bytes.
+        len: u32,
+    },
+    /// Represents a 32-bit memory mapped region.
+    Memory32Bit {
+        /// Start address of the 32-bit memory mapped region.
+        addr: u32,
+        /// Length of the region, in bytes.
+        len: u32,
+    },
+    /// Represents a 64-bit memory mapped region.
+    Memory64Bit {
+        /// Start address of the 64-bit memory mapped region.
+        addr: u64,
+        /// Length of the region, in bytes.
+        len: u64,
+    },
+}
+
+impl PciBarRegion {
+    /// Describe an IO space BAR region.
+    pub fn new_io_region(addr: u32, len: u32) -> Result<Self> {
+        addr.checked_add(len)
+            .ok_or(Error::BarAddressInvalid(addr.into(), len.into()))?;
+        validate_dword_alignment(addr as usize)?;
+        Ok(PciBarRegion::Io { addr, len })
+    }
+
+    /// Describe a memory mapped 32bit BAR region.
+    pub fn new_32bit_mem_region(addr: u32, len: u32) -> Result<Self> {
+        addr.checked_add(len)
+            .ok_or(Error::BarAddressInvalid(addr.into(), len.into()))?;
+        validate_dword_alignment(addr as usize)?;
+        Ok(PciBarRegion::Memory32Bit { addr, len })
+    }
+
+    /// Describe a memory mapped 64bit BAR region.
+    pub fn new_64bit_mem_region(addr: u64, len: u64) -> Result<Self> {
+        addr.checked_add(len)
+            .ok_or(Error::BarAddressInvalid(addr.into(), len.into()))?;
+        validate_dword_alignment(addr as usize)?;
+        Ok(PciBarRegion::Memory64Bit { addr, len })
+    }
+}
+
+#[derive(Copy, Clone)]
+/// Configuration of a Base Address Register.
+pub struct PciBarConfig {
+    /// Index of the BAR.
+    pub index: usize,
+    /// Region referenced by BAR.
+    pub region: PciBarRegion,
+    /// Prefetchable status.
+    pub prefetchable: PciBarPrefetchable,
+}
+
+#[derive(Copy, Clone)]
+/// Configuration of a ROM Base Address Register.
+pub struct PciRomBarConfig {
+    /// Region referenced by BAR.
+    pub region: PciBarRegion,
+    /// Enable bit.
+    pub enable: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_io_bar_region() {
+        let r = PciBarRegion::new_io_region(0x1000, 4096).unwrap();
+        assert!(
+            r == PciBarRegion::Io {
+                addr: 0x1000,
+                len: 4096
+            }
+        );
+
+        let err_len = u32::MAX - 512;
+        match PciBarRegion::new_io_region(0x1000, err_len) {
+            Err(Error::BarAddressInvalid(0x1000, len)) => {
+                assert_eq!(len, err_len as u64);
+            }
+            _ => assert!(false),
+        }
+
+        match PciBarRegion::new_io_region(0x1003, 4096) {
+            Err(Error::Access(ConfigSpaceAccessError::UnalignedAccess)) => {}
+            _ => assert!(false),
+        }
+    }
+
+    #[test]
+    fn test_32bit_mem_bar_region() {
+        let r = PciBarRegion::new_32bit_mem_region(0x1000, 4096).unwrap();
+        assert!(
+            r == PciBarRegion::Memory32Bit {
+                addr: 0x1000,
+                len: 4096
+            }
+        );
+
+        let err_len = u32::MAX - 512;
+        match PciBarRegion::new_32bit_mem_region(0x1000, err_len) {
+            Err(Error::BarAddressInvalid(0x1000, len)) => {
+                assert_eq!(len, err_len as u64);
+            }
+            _ => assert!(false),
+        }
+
+        match PciBarRegion::new_32bit_mem_region(0x1003, 4096) {
+            Err(Error::Access(ConfigSpaceAccessError::UnalignedAccess)) => {}
+            _ => assert!(false),
+        }
+    }
+
+    #[test]
+    fn test_64bit_mem_bar_region() {
+        let r = PciBarRegion::new_64bit_mem_region(0x1000, 4096).unwrap();
+        assert!(
+            r == PciBarRegion::Memory64Bit {
+                addr: 0x1000,
+                len: 4096
+            }
+        );
+
+        let big_len = u64::MAX / 2;
+        let r = PciBarRegion::new_64bit_mem_region(0x1000, big_len).unwrap();
+        assert!(
+            r == PciBarRegion::Memory64Bit {
+                addr: 0x1000,
+                len: big_len
+            }
+        );
+
+        let err_len = u64::MAX - 512;
+        match PciBarRegion::new_64bit_mem_region(0x1000, err_len) {
+            Err(Error::BarAddressInvalid(0x1000, len)) => {
+                assert_eq!(len, err_len as u64);
+            }
+            _ => assert!(false),
+        }
+
+        match PciBarRegion::new_64bit_mem_region(0x1003, 4096) {
+            Err(Error::Access(ConfigSpaceAccessError::UnalignedAccess)) => {}
+            _ => assert!(false),
+        }
+    }
+}

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -1,0 +1,81 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::pci_config::PciSubclass;
+
+// PCI-to-PCI Bridge constants.
+/// Byte offset of the start of the BARs in the PCI configuration space.
+pub const BARS_START_OFFSET: usize = 0x10;
+/// Number of BARs in a generic PCI device configuration space.
+pub const NUM_BARS: usize = 2;
+/// Offset of Primary Bus Number in the PCI configuration space.
+pub const PRIMARY_BUS_NUMBER_OFFSET: usize = 0x18;
+/// Offset of Secondary Bus Number in the PCI configuration space.
+pub const SECONDARY_BUS_NUMBER_OFFSET: usize = 0x19;
+/// Offset of Subordinate Bus Number in the PCI configuration space.
+pub const SUBORDINATE_BUS_NUMBER: usize = 0x1a;
+/// Offset of Secondary Latency Timer in the PCI configuration space.
+pub const SECONDARY_LATENCY_TIMER: usize = 0x1b;
+/// Offset of IO Base in the PCI configuration space.
+pub const IO_BASE_OFFSET: usize = 0x1c;
+/// Offset of IO Limit in the PCI configuration space.
+pub const IO_LIMIT_OFFSET: usize = 0x1d;
+/// Offset of Secondary Status in the PCI configuration space.
+pub const SECONDARY_STATUS_OFFSET: usize = 0x1e;
+/// Offset of Memory Base in the PCI configuration space.
+pub const MEMORY_BASE_OFFSET: usize = 0x20;
+/// Offset of Memory Limit in the PCI configuration space.
+pub const MEMORY_LIMIT_OFFSET: usize = 0x22;
+/// Offset of Prefetchable Memory Base in the PCI configuration space.
+pub const PREFETCH_MEMORY_BASE_OFFSET: usize = 0x24;
+/// Offset of Prefetchable Memory Limit in the PCI configuration space.
+pub const PREFETCH_MEMORY_LIMIT_OFFSET: usize = 0x26;
+/// Offset of Prefetchable Base Upper 32 bits in the PCI configuration space.
+pub const PREFETCH_BASE_UPPER_OFFSET: usize = 0x28;
+/// Offset of Prefetchable Limit Upper 32 bits in the PCI configuration space.
+pub const PREFETCH_LIMIT_UPPER_OFFSET: usize = 0x2c;
+/// Offset of IO Base Upper 32 bits in the PCI configuration space.
+pub const IO_BASE_UPPER_OFFSET: usize = 0x30;
+/// Offset of IO Base Lower 32 bits in the PCI configuration space.
+pub const IO_BASE_LOWER_OFFSET: usize = 0x32;
+/// Offset of Capabilities Pointer in the PCI configuration space.
+pub const CAPABILITIES_POINTER_OFFSET: usize = 0x34;
+/// Offset of the ROM BAR in the PCI configuration space.
+pub const ROM_BAR_OFFSET: usize = 0x38;
+/// Offset of Interrupt Line in the PCI configuration space.
+pub const INTERRUPT_LINE_OFFSET: usize = 0x3c;
+/// Offset of Interrupt Pin in the PCI configuration space.
+pub const INTERRUPT_PIN_OFFSET: usize = 0x3d;
+/// Offset of Bridge Control in the PCI configuration space.
+pub const BRIDGE_CONTROL_OFFSET: usize = 0x3e;
+
+#[derive(Copy, Clone)]
+/// Enum representing PCI bridge subclasses as presented in the PCI
+/// specification.
+pub enum PciBridgeSubclass {
+    /// Host bridge.
+    HostBridge = 0x00,
+    /// PCI-to-ISA bridge.
+    IsaBridge = 0x01,
+    /// PCI-to-PCI bridge.
+    PciToPciBridge = 0x04,
+    /// Unknown/unimplemented bridge types.
+    OtherBridgeDevice = 0x80,
+}
+
+impl From<u8> for PciBridgeSubclass {
+    fn from(item: u8) -> Self {
+        match item {
+            0x00 => Self::HostBridge,
+            0x01 => Self::IsaBridge,
+            0x04 => Self::PciToPciBridge,
+            0x80 | _ => Self::OtherBridgeDevice,
+        }
+    }
+}
+
+impl PciSubclass for PciBridgeSubclass {
+    fn value(&self) -> u8 {
+        *self as u8
+    }
+}

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,0 +1,126 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::bar::{Error as BarAddressError, PciBarConfig, PciBarRegion, PciRomBarConfig};
+use crate::pci_config::{Error as ConfigSpaceAccessError, PciConfig};
+use std::fmt;
+
+type Result<T> = std::result::Result<T, Error>;
+
+// Generic device PCI device constants.
+/// Byte offset of the start of the BARs in the PCI configuration space.
+pub const BARS_START_OFFSET: usize = 0x10;
+/// Number of BARs in a generic PCI device configuration space.
+pub const NUM_BARS: usize = 6;
+/// Offset of Cardbus CIS pointer in the PCI configuration space.
+pub const CARDBUS_CIS_POINTER_OFFSET: usize = 0x28;
+/// Offset of Subsystem Vendor ID in the PCI configuration space.
+pub const SUBSYSTEM_VENDOR_ID_OFFSET: usize = 0x2c;
+/// Offset of Subsystem ID in the PCI configuration space.
+pub const SUBSYSTEM_ID_OFFSET: usize = 0x2e;
+/// Offset of the ROM BAR in the PCI configuration space.
+pub const ROM_BAR_OFFSET: usize = 0x30;
+/// Register number of the ROM BAR in the PCI configuration space.
+pub const ROM_BAR_REG_IDX: usize = 0xc;
+/// Offset of Capabilities Pointer in the PCI configuration space.
+pub const CAPABILITIES_POINTER_OFFSET: usize = 0x34;
+/// Offset of Interrupt Line in the PCI configuration space.
+pub const INTERRUPT_LINE_OFFSET: usize = 0x3c;
+/// Offset of Interrupt Pin in the PCI configuration space.
+pub const INTERRUPT_PIN_OFFSET: usize = 0x3d;
+/// Offset of Min Grant in the PCI configuration space.
+pub const MIN_GRANT_OFFSET: usize = 0x3e;
+/// Offset of Max Latency in the PCI configuration space.
+pub const MAX_LATENCY_OFFSET: usize = 0x3f;
+
+#[derive(Debug)]
+/// Error type for PCI Device configuration space accesses.
+pub enum Error {
+    /// PCI common configuration space access error.
+    Access(ConfigSpaceAccessError),
+    /// BAR addressing error.
+    BarAddress(BarAddressError),
+    /// Invalid BAR slot.
+    BarIndex,
+    /// BAR slot is already used.
+    BarInUse(usize),
+    /// BAR slot is already used by a 64-bit BAR.
+    BarInUse64(usize),
+    /// Requested BAR is unavailable.
+    BarInvalid(usize),
+    /// Requested 64-bit BAR is unavailable.
+    BarInvalid64(usize),
+    /// ROM BAR slot is already used.
+    RomBarInUse,
+    /// ROM BAR is unavailable.
+    RomBarInvalid,
+}
+
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Error::*;
+
+        match self {
+            Access(e) => write!(f, "access error: {}", e),
+            BarAddress(e) => write!(f, "BAR region: {}", e),
+            BarIndex => write!(f, "invalid BAR slot"),
+            BarInUse(slot) => write!(f, "BAR slot {} already used", slot),
+            BarInUse64(slot) => write!(f, "BAR slot {} already used by 64bit BAR", slot),
+            BarInvalid(slot) => write!(f, "requested BAR {} unavailable", slot),
+            BarInvalid64(slot) => write!(f, "requested 64bit BAR {} unavailable", slot),
+            RomBarInUse => write!(f, "ROM BAR slot already used"),
+            RomBarInvalid => write!(f, "ROM BAR unavailable"),
+        }
+    }
+}
+
+impl From<ConfigSpaceAccessError> for Error {
+    fn from(e: ConfigSpaceAccessError) -> Self {
+        Error::Access(e)
+    }
+}
+
+impl From<BarAddressError> for Error {
+    fn from(e: BarAddressError) -> Self {
+        Error::BarAddress(e)
+    }
+}
+
+/// A PCI Device (header type 0x00) configuration space abstraction.
+///
+/// The most important feature of the PCI device configuration space is
+/// the Base Address Register representation in memory. A PCI Device
+/// configuration space must be able to:
+/// - add BARs, through `add_bar()`
+/// - retrieve BAR addresses, through `bar_address()`
+/// - add the ROM BAR, through `add_rom_bar()`
+/// - retrieve the ROM BAR address, through `rom_bar_address()`
+pub trait PciDeviceConfig: PciConfig {
+    /// Add a Base Address Register to the configuration space.
+    ///
+    /// # Arguments
+    ///
+    /// * `config`:   the configuration of the BAR to be added
+    fn add_bar(&mut self, config: PciBarConfig) -> Result<()>;
+
+    /// Add a ROM Base Address Register to the configuration space.
+    ///
+    /// # Arguments
+    ///
+    /// * `config`:   the configuration of the ROM BAR to be added
+    fn add_rom_bar(&mut self, config: PciRomBarConfig) -> Result<()>;
+
+    /// Retrieves the address in a Base Address Register from the configuration
+    /// space.
+    ///
+    /// # Arguments
+    ///
+    /// * `idx`:   the index of the requested BAR
+    fn bar_address(&self, idx: usize) -> Result<PciBarRegion>;
+
+    /// Retrieves the address in the ROM Base Address Register from the
+    /// configuration space.
+    fn rom_bar_address(&self) -> Result<PciBarRegion>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,34 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module provides an abstraction over a subset of the PCI configuration
+//! space functionality necessary for emulating a PCI device.
+//!
+//! The PCI specification states that every PCI compatible device must provide
+//! a standardized configuration space of 256 bytes, organized into registers
+//! of 4 bytes. All devices share the layout of the first 4 registers, defined
+//! in the PCI specification.
+//!
+//! Abstractions for the common PCI configuration space are present in the
+//! `pci_config` module.
+//!
+//! The header type determines what kind of device that is configured and the
+//! layout of the next 12 registers. Header type 0x00 is for generic PCI
+//! devices, present in the `device` module. Header type 0x01 is for PCI
+//! bridges, present in the `bridge` module. Header type 0x02 is for PCI
+//! Cardbus bridges and is not implemented in this crate.
+//!
+//! Though not present right now, the aim of this crate is to provide a
+//! Host Bridge / PCI Bus abstraction which would then be integrated with the
+//! `Device` and `MutDevice` traits in `vm-device`.
+
 #![deny(missing_docs)]
-//! Dummy crate needs high-level documentation.
-/// Dummy public function needs documentation.
-pub fn it_works() {
-    assert_ne!(0, 1);
-}
+
+/// PCI Base Address Register addressing and configuration.
+pub mod bar;
+/// PCI Bridge device (header type 0x01) configuration.
+pub mod bridge;
+/// PCI generic device (header type 0x00) configuration.
+pub mod device;
+/// Common PCI configuration.
+pub mod pci_config;

--- a/src/pci_config.rs
+++ b/src/pci_config.rs
@@ -1,0 +1,714 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt;
+
+type Result<T> = std::result::Result<T, Error>;
+
+/// Represents (byte offset, len) for a capability in the config space.
+pub type CapabilityRegion = (usize, usize);
+
+// PCI common configuration constants.
+/// Length of PCI configuration space, in bytes.
+pub const PCI_CONFIGURATION_SPACE_SIZE: usize = 256;
+/// Length of PCIe configuration space, in bytes.
+pub const PCIE_CONFIGURATION_SPACE_SIZE: usize = 4096;
+/// Number of PCIe configuration space registers.
+pub const NUM_CONFIGURATION_REGISTERS: usize = 1024;
+/// Offset of vendor ID in the PCI configuration space.
+pub const VENDOR_ID_OFFSET: usize = 0x00;
+/// Offset of device ID in the PCI configuration space.
+pub const DEVICE_ID_OFFSET: usize = 0x02;
+/// Offset of command in the PCI configuration space.
+pub const COMMAND_OFFSET: usize = 0x04;
+/// Offset of status in the PCI configuration space.
+pub const STATUS_OFFSET: usize = 0x06;
+/// Offset of revision ID in the PCI configuration space.
+pub const REVISION_ID_OFFSET: usize = 0x08;
+/// Offset of programming interface in the PCI configuration space.
+pub const PROG_IF_OFFSET: usize = 0x09;
+/// Offset of subclass in the PCI configuration space.
+pub const SUBCLASS_OFFSET: usize = 0x0A;
+/// Offset of class code in the PCI configuration space.
+pub const CLASS_CODE_OFFSET: usize = 0x0B;
+/// Offset of cache line size in the PCI configuration space.
+pub const CACHE_LINE_SIZE_OFFSET: usize = 0x0C;
+/// Offset of latency timer in the PCI configuration space.
+pub const LATENCY_TIMER_OFFSET: usize = 0x0D;
+/// Offset of header type in the PCI configuration space.
+pub const HEADER_TYPE_OFFSET: usize = 0x0E;
+/// Offset of BIST in the PCI configuration space.
+pub const BIST_OFFSET: usize = 0x0F;
+
+// Check to ensure all address accesses to the configuration space are 32bit
+// aligned.
+pub(crate) fn validate_dword_alignment(addr: usize) -> Result<()> {
+    if addr % 4 != 0 {
+        return Err(Error::UnalignedAccess);
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+/// Error type for PCI configuration space accesses.
+pub enum Error {
+    /// Offset of the access to the configuration space has improper alignment.
+    UnalignedAccess,
+    /// Offset of the access to the configuration space is out of bounds.
+    OffsetOutOfBounds,
+    // Length of the buffer in the access to the configuration space is
+    // invalid.
+    // Only used if `read` and `write` methods use buffers and not `u32`s.
+
+    // InvalidDataLen,
+}
+
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Error::*;
+
+        match *self {
+            UnalignedAccess => write!(f, "unaligned access"),
+            OffsetOutOfBounds => write!(f, "out of bounds access"),
+        }
+    }
+}
+
+/// Enum representing PCI header types as presented in the PCI specification.
+#[derive(Copy, Clone)]
+pub enum PciHeaderType {
+    /// Generic PCI device.
+    Device = 0x00,
+    /// PCI-to-PCI bridge.
+    PciToPciBridge = 0x01,
+    /// PCI-to-Cardbus bridge.
+    PciToCardbusBridge = 0x02,
+    /// Unknown header type.
+    Unknown = 0xff,
+}
+
+impl From<u8> for PciHeaderType {
+    fn from(item: u8) -> Self {
+        match item {
+            0x00 => Self::Device,
+            0x01 => Self::PciToPciBridge,
+            0x02 => Self::PciToCardbusBridge,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+/// Enum representing PCI classes as presented in the PCI specification.
+#[allow(dead_code)]
+#[derive(Copy, Clone)]
+pub enum PciClassCode {
+    /// Precursor to class codes (introduced in PCI rev 2.0)
+    TooOld,
+    /// Mass storage controller.
+    MassStorage,
+    /// Network controller.
+    NetworkController,
+    /// Display controller.
+    DisplayController,
+    /// Media controller.
+    MultimediaController,
+    /// Memory controller.
+    MemoryController,
+    /// Bridge device.
+    BridgeDevice,
+    /// Simple communications controller.
+    SimpleCommunicationController,
+    /// Base system peripheral.
+    BaseSystemPeripheral,
+    /// Input device.
+    InputDevice,
+    /// Docking station.
+    DockingStation,
+    /// Processor.
+    Processor,
+    /// Serial bus controller.
+    SerialBusController,
+    /// Wireless controller.
+    WirelessController,
+    /// Intelligent IO controller.
+    IntelligentIoController,
+    /// Encryption controller.
+    EncryptionController,
+    /// Signal processing.
+    SignalProcessing,
+    /// Processing accelerator.
+    ProcessingAccelerator,
+    /// Non-essential instrumentation.
+    NonEssentialInstrumentation,
+    /// Unknown class.
+    Other = 0xff,
+}
+
+impl PciClassCode {
+    /// Represent the class as a byte to be used in the PCI configuration
+    /// space.
+    pub fn value(self) -> u8 {
+        self as u8
+    }
+}
+
+impl From<u8> for PciClassCode {
+    fn from(item: u8) -> Self {
+        match item {
+            0x00 => Self::TooOld,
+            0x01 => Self::MassStorage,
+            0x02 => Self::NetworkController,
+            0x03 => Self::DisplayController,
+            0x04 => Self::MultimediaController,
+            0x05 => Self::MemoryController,
+            0x06 => Self::BridgeDevice,
+            0x07 => Self::SimpleCommunicationController,
+            0x08 => Self::BaseSystemPeripheral,
+            0x09 => Self::InputDevice,
+            0x0a => Self::DockingStation,
+            0x0b => Self::Processor,
+            0x0c => Self::SerialBusController,
+            0x0d => Self::WirelessController,
+            0x0e => Self::IntelligentIoController,
+            0x0f => Self::EncryptionController,
+            0x10 => Self::SignalProcessing,
+            0x11 => Self::ProcessingAccelerator,
+            0x12 => Self::NonEssentialInstrumentation,
+            0xff | _ => Self::Other,
+        }
+    }
+}
+
+/// A PCI subclass abstraction.
+///
+/// Each class in `PciClassCode` can specify a unique set of subclasses. This
+/// trait is implemented by each subclass. It allows use of a trait object to
+/// generate configurations.
+pub trait PciSubclass: From<u8> {
+    /// Represent the subclass as a byte to be used in the PCI configuration
+    /// space.
+    fn value(&self) -> u8;
+}
+
+/// A PCI programming interface abstraction.
+///
+/// Each combination of `PciClassCode` and `PciSubclass` can specify a set of
+/// register-level programming interfaces. This trait is implemented by each
+/// programming interface. It allows use of a trait object to generate
+/// configurations.
+pub trait PciProgrammingInterface: From<u8> {
+    /// Represent the programming interface as a byte to be used in the PCI
+    /// configuration space.
+    fn value(&self) -> u8;
+}
+
+/// Enum representing PCI capability IDs as presented in the PCI specification.
+#[derive(PartialEq, Copy, Clone)]
+#[allow(dead_code)]
+#[allow(non_camel_case_types)]
+#[repr(C)]
+pub enum PciCapabilityId {
+    /// Reserved.
+    ListId = 0,
+    /// Power Management Interface.
+    PowerManagement = 0x01,
+    /// Accelerated Graphics Port.
+    AcceleratedGraphicsPort = 0x02,
+    /// Vital Product Data.
+    VitalProductData = 0x03,
+    /// Slot Identification.
+    SlotIdentification = 0x04,
+    /// Message Signaled Interrupts.
+    MessageSignalledInterrupts = 0x05,
+    /// CompactPCI Hot Swap.
+    CompactPciHotSwap = 0x06,
+    /// PCI-X.
+    PciX = 0x07,
+    /// HyperTransport.
+    HyperTransport = 0x08,
+    /// Vendor specific.
+    VendorSpecific = 0x09,
+    /// Debug port.
+    DebugPort = 0x0A,
+    /// CompactPCI central resource control.
+    CompactPciCentralResourceControl = 0x0B,
+    /// PCI Hot-Plug.
+    PciHotPlug = 0x0C,
+    /// PCI Bridge Subsystem Vendor ID.
+    BridgeSubsystemVendorDeviceId = 0x0D,
+    /// AGP 8x.
+    Agp8X = 0x0E,
+    /// Secure Device.
+    SecureDevice = 0x0F,
+    /// PCI Express.
+    PciExpress = 0x10,
+    /// MSI-X.
+    MsiX = 0x11,
+    /// SATA Data Index.
+    SataDataIndex = 0x12,
+    /// PCI Advanced Features.
+    PciAdvancedFeatures = 0x13,
+    /// PCI Enhanced Allocation.
+    PciEnhancedAllocation = 0x14,
+}
+
+impl From<u8> for PciCapabilityId {
+    fn from(item: u8) -> Self {
+        match item {
+            0x00 => PciCapabilityId::ListId,
+            0x01 => PciCapabilityId::PowerManagement,
+            0x02 => PciCapabilityId::AcceleratedGraphicsPort,
+            0x03 => PciCapabilityId::VitalProductData,
+            0x04 => PciCapabilityId::SlotIdentification,
+            0x05 => PciCapabilityId::MessageSignalledInterrupts,
+            0x06 => PciCapabilityId::CompactPciHotSwap,
+            0x07 => PciCapabilityId::PciX,
+            0x08 => PciCapabilityId::HyperTransport,
+            0x09 => PciCapabilityId::VendorSpecific,
+            0x0A => PciCapabilityId::DebugPort,
+            0x0B => PciCapabilityId::CompactPciCentralResourceControl,
+            0x0C => PciCapabilityId::PciHotPlug,
+            0x0D => PciCapabilityId::BridgeSubsystemVendorDeviceId,
+            0x0E => PciCapabilityId::Agp8X,
+            0x0F => PciCapabilityId::SecureDevice,
+            0x10 => PciCapabilityId::PciExpress,
+            0x11 => PciCapabilityId::MsiX,
+            0x12 => PciCapabilityId::SataDataIndex,
+            0x13 => PciCapabilityId::PciAdvancedFeatures,
+            0x14 => PciCapabilityId::PciEnhancedAllocation,
+            _ => PciCapabilityId::ListId,
+        }
+    }
+}
+
+/// A PCI capability abstraction.
+///
+/// For the purposes of representing capabilities in the PCI configuration
+/// space, an entity which implements `PciCapability` must be able to present
+/// itself as a byte slice and provide its unique capability ID.
+///
+/// # Example
+/// ```
+/// use vm_pci::pci_config::{PciCapability, PciCapabilityId};
+///
+/// #[repr(packed)]
+/// struct PcieCap {
+///     ptype: u16,
+///     data: [u8; 59],
+/// }
+///
+/// impl PciCapability for PcieCap {
+///     fn bytes(&self) -> &[u8] {
+///         // Safe because struct is packed.
+///         unsafe {
+///             std::slice::from_raw_parts(
+///                 self as *const PcieCap as *const u8,
+///                 std::mem::size_of::<PcieCap>()
+///             )
+///         }
+///     }
+///
+///     fn id(&self) -> PciCapabilityId {
+///         PciCapabilityId::PciExpress
+///     }
+/// }
+/// ```
+pub trait PciCapability {
+    /// Returns the byte representation of the capability in the configuration
+    /// space.
+    fn bytes(&self) -> &[u8];
+
+    /// Returns the ID of the capability, as presented in the PCI
+    /// specification.
+    fn id(&self) -> PciCapabilityId;
+}
+
+/// Allows access to a PCI configuration space.
+///
+/// # Example
+/// ```
+/// use vm_pci::pci_config::{Error as ConfigSpaceAccessError, PciConfig};
+///
+/// struct DummyConfig {
+///     registers: [u32; 64],
+/// }
+///
+/// impl PciConfig for DummyConfig {
+///     fn read_register(&self, idx: usize) -> std::result::Result<u32, ConfigSpaceAccessError> {
+///         if idx >= 64 {
+///             return Err(ConfigSpaceAccessError::OffsetOutOfBounds);
+///         }
+///         Ok(self.registers[idx])
+///     }
+///
+///     fn write_register(
+///         &mut self,
+///         data: u32,
+///         idx: usize,
+///    ) -> std::result::Result<(), ConfigSpaceAccessError> {
+///         if idx >= 64 {
+///             return Err(ConfigSpaceAccessError::OffsetOutOfBounds);
+///         }
+///         self.registers[idx] = data;
+///         Ok(())
+///     }
+/// }
+/// ```
+pub trait PciConfig {
+    // Should this be done with registers or bytes??
+    //fn read_data(&self, data: &mut[u8], offset: usize) -> Result<()>;
+    //fn write_data(&mut self, data: &[u8], offset: usize) -> Result<()>;
+
+    /// Read a register from the configuration space.
+    ///
+    /// # Arguments
+    ///
+    /// * `idx`:   index of the register
+    fn read_register(&self, idx: usize) -> Result<u32>;
+
+    /// Write to a register in the configuration space.
+    ///
+    /// # Arguments
+    ///
+    /// * `data`:   data to be written
+    /// * `idx`:    index of the register
+    fn write_register(&mut self, data: u32, idx: usize) -> Result<()>;
+
+    /// Aligned read of a dword from the given offset in configuration space.
+    ///
+    /// # Arguments
+    ///
+    /// * `offset`:   offset of the dword to be read
+    fn read_dword(&self, offset: usize) -> Result<u32> {
+        validate_dword_alignment(offset)?;
+        let reg_offset = offset / 4;
+        self.read_register(reg_offset)
+    }
+
+    /// Aligned read of a word from the given offset in configuration space.
+    ///
+    /// # Arguments
+    ///
+    /// * `offset`:   offset of the word to be read
+    fn read_word(&self, offset: usize) -> Result<u16> {
+        let reg_offset = offset / 4;
+        let byte_idx = offset % 4;
+        let res = match byte_idx {
+            0 => self.read_register(reg_offset)? & 0x0000_ffff,
+            2 => (self.read_register(reg_offset)? & 0xffff_0000) >> 16,
+            1 | 3 => {
+                return Err(Error::UnalignedAccess);
+            }
+            _ => unreachable!(),
+        };
+        // Or u16::try_from(res).unwrap()
+        Ok(res as u16)
+    }
+
+    /// Aligned read of a byte from the given offset in configuration space.
+    ///
+    /// # Arguments
+    ///
+    /// * `offset`:   offset of the byte to be read
+    fn read_byte(&self, offset: usize) -> Result<u8> {
+        let reg_offset = offset / 4;
+        let byte_idx = offset % 4;
+        let res = match byte_idx {
+            0 => self.read_register(reg_offset)? & 0x0000_00ff,
+            1 => (self.read_register(reg_offset)? & 0x0000_ff00) >> 8,
+            2 => (self.read_register(reg_offset)? & 0x00ff_0000) >> 16,
+            3 => (self.read_register(reg_offset)? & 0xff00_0000) >> 24,
+            _ => unreachable!(),
+        };
+        // Or u8::try_from(res).unwrap()
+        Ok(res as u8)
+    }
+
+    /// Aligned write of a dword at the given offset in configuration space.
+    ///
+    /// # Arguments
+    ///
+    /// * `offset`:   offset of the dword to be written
+    fn write_dword(&mut self, value: u32, offset: usize) -> Result<()> {
+        validate_dword_alignment(offset)?;
+        let reg_offset = offset / 4;
+        self.write_register(value, reg_offset)
+    }
+
+    /// Aligned write of a word at the given offset in configuration space.
+    ///
+    /// # Arguments
+    ///
+    /// * `offset`:   offset of the word to be written
+    fn write_word(&mut self, value: u16, offset: usize) -> Result<()> {
+        let reg_offset = offset / 4;
+        let byte_idx = offset % 4;
+        let res = match byte_idx {
+            0 => (self.read_register(reg_offset)? & 0xffff_0000) | u32::from(value),
+            2 => (self.read_register(reg_offset)? & 0x0000_ffff) | (u32::from(value) << 16),
+            1 | 3 => {
+                return Err(Error::UnalignedAccess);
+            }
+            _ => unreachable!(),
+        };
+        self.write_register(res, reg_offset)
+    }
+
+    /// Aligned write of a byte at the given offset in configuration space.
+    ///
+    /// # Arguments
+    ///
+    /// * `offset`:   offset of the byte to be written
+    fn write_byte(&mut self, value: u8, offset: usize) -> Result<()> {
+        let reg_offset = offset / 4;
+        let byte_idx = offset % 4;
+        let res = match byte_idx {
+            0 => (self.read_register(reg_offset)? & 0xffff_ff00) | u32::from(value),
+            1 => (self.read_register(reg_offset)? & 0xffff_00ff) | (u32::from(value) << 8),
+            2 => (self.read_register(reg_offset)? & 0xff00_ffff) | (u32::from(value) << 16),
+            3 => (self.read_register(reg_offset)? & 0x00ff_ffff) | (u32::from(value) << 24),
+            _ => unreachable!(),
+        };
+        self.write_register(res, reg_offset)
+    }
+
+    /// Reads the vendor ID from the configuration space.
+    fn vendor_id(&self) -> Result<u16> {
+        self.read_word(VENDOR_ID_OFFSET)
+    }
+
+    /// Writes the vendor ID to the configuration space.
+    fn write_vendor_id(&mut self, device_id: u16) -> Result<()> {
+        self.write_word(device_id, VENDOR_ID_OFFSET)
+    }
+
+    /// Reads the device ID from the configuration space.
+    fn device_id(&self) -> Result<u16> {
+        self.read_word(DEVICE_ID_OFFSET)
+    }
+
+    /// Writes the device ID to the configuration space.
+    fn write_device_id(&mut self, device_id: u16) -> Result<()> {
+        self.write_word(device_id, DEVICE_ID_OFFSET)
+    }
+
+    /// Reads the command from the configuration space.
+    fn command(&self) -> Result<u16> {
+        self.read_word(COMMAND_OFFSET)
+    }
+
+    /// Writes the command to the configuration space.
+    fn write_command(&mut self, command: u16) -> Result<()> {
+        self.write_word(command, COMMAND_OFFSET)
+    }
+
+    /// Reads the status from the configuration space.
+    fn status(&self) -> Result<u16> {
+        self.read_word(STATUS_OFFSET)
+    }
+
+    /// Writes the status to the configuration space.
+    fn write_status(&mut self, status: u16) -> Result<()> {
+        self.write_word(status, STATUS_OFFSET)
+    }
+
+    /// Reads the revision ID from the configuration space.
+    fn revision_id(&self) -> Result<u8> {
+        self.read_byte(REVISION_ID_OFFSET)
+    }
+
+    /// Writes the revision ID to the configuration space.
+    fn write_revision_id(&mut self, revision_id: u8) -> Result<()> {
+        self.write_byte(revision_id, REVISION_ID_OFFSET)
+    }
+
+    /// Reads the programming interface from the configuration space.
+    fn prog_if(&self) -> Result<u8> {
+        self.read_byte(PROG_IF_OFFSET)
+    }
+
+    /// Writes the programming interface to the configuration space.
+    fn write_prog_if(&mut self, prog_if: u8) -> Result<()> {
+        self.write_byte(prog_if, PROG_IF_OFFSET)
+    }
+
+    /// Reads the subclass from the configuration space.
+    fn subclass(&self) -> Result<u8> {
+        self.read_byte(SUBCLASS_OFFSET)
+    }
+
+    /// Writes the subclass to the configuration space.
+    fn write_subclass(&mut self, subclass: u8) -> Result<()> {
+        self.write_byte(subclass, SUBCLASS_OFFSET)
+    }
+
+    /// Reads the class code from the configuration space.
+    fn class_code(&self) -> Result<u8> {
+        self.read_byte(CLASS_CODE_OFFSET)
+    }
+
+    /// Writes the class code to the configuration space.
+    fn write_class_code(&mut self, class_code: u8) -> Result<()> {
+        self.write_byte(class_code, CLASS_CODE_OFFSET)
+    }
+
+    /// Reads the cache line size from the configuration space.
+    fn cache_line_size(&self) -> Result<u8> {
+        self.read_byte(CACHE_LINE_SIZE_OFFSET)
+    }
+
+    /// Writes the cache line size to the configuration space.
+    fn write_cache_line_size(&mut self, cache_line_size: u8) -> Result<()> {
+        self.write_byte(cache_line_size, CACHE_LINE_SIZE_OFFSET)
+    }
+
+    /// Reads the latency timer from the configuration space.
+    fn latency_timer(&self) -> Result<u8> {
+        self.read_byte(LATENCY_TIMER_OFFSET)
+    }
+
+    /// Writes the latency timer to the configuration space.
+    fn write_latency_timer(&mut self, latency_timer: u8) -> Result<()> {
+        self.write_byte(latency_timer, LATENCY_TIMER_OFFSET)
+    }
+
+    /// Reads the header type from the configuration space.
+    fn header_type(&self) -> Result<u8> {
+        self.read_byte(HEADER_TYPE_OFFSET)
+    }
+
+    /// Writes the header type to the configuration space.
+    fn write_header_type(&mut self, header_type: u8) -> Result<()> {
+        self.write_byte(header_type, HEADER_TYPE_OFFSET)
+    }
+
+    /// Reads the BIST from the configuration space.
+    fn bist(&self) -> Result<u8> {
+        self.read_byte(BIST_OFFSET)
+    }
+
+    /// Writes the BIST to the configuration space.
+    fn write_bist(&mut self, bist: u8) -> Result<()> {
+        self.write_byte(bist, BIST_OFFSET)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_dword_alignment() {
+        match validate_dword_alignment(0x1000) {
+            Ok(()) => {}
+            _ => assert!(false),
+        }
+
+        match validate_dword_alignment(0x1003) {
+            Err(Error::UnalignedAccess) => {}
+            _ => assert!(false),
+        }
+    }
+
+    struct DummyConfig {
+        registers: [u32; 64],
+    }
+
+    impl PciConfig for DummyConfig {
+        fn read_register(&self, idx: usize) -> std::result::Result<u32, Error> {
+            if idx >= 64 {
+                return Err(Error::OffsetOutOfBounds);
+            }
+            Ok(self.registers[idx])
+        }
+
+        fn write_register(&mut self, data: u32, idx: usize) -> std::result::Result<(), Error> {
+            if idx >= 64 {
+                return Err(Error::OffsetOutOfBounds);
+            }
+            self.registers[idx] = data;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_config_read() {
+        let mut config = DummyConfig {
+            registers: [0u32; 64],
+        };
+        config.registers[0] = 0xdead_beef;
+        config.registers[4] = 0xddcc_bbaa;
+
+        // Byte reads. All byte reads are aligned.
+        assert_eq!(config.read_byte(0).unwrap(), 0xef);
+        assert_eq!(config.read_byte(1).unwrap(), 0xbe);
+        assert_eq!(config.read_byte(2).unwrap(), 0xad);
+        assert_eq!(config.read_byte(3).unwrap(), 0xde);
+        assert_eq!(config.read_byte(16).unwrap(), 0xaa);
+        assert_eq!(config.read_byte(17).unwrap(), 0xbb);
+        assert_eq!(config.read_byte(18).unwrap(), 0xcc);
+        assert_eq!(config.read_byte(19).unwrap(), 0xdd);
+
+        // Word reads.
+        assert_eq!(config.read_word(0).unwrap(), 0xbeef);
+        assert_eq!(config.read_word(2).unwrap(), 0xdead);
+        assert!(config.read_word(1).is_err());
+        assert!(config.read_word(3).is_err());
+        assert_eq!(config.read_word(16).unwrap(), 0xbbaa);
+        assert_eq!(config.read_word(18).unwrap(), 0xddcc);
+        assert!(config.read_word(17).is_err());
+        assert!(config.read_word(19).is_err());
+
+        // Dword reads.
+        assert_eq!(config.read_dword(0).unwrap(), 0xdead_beef);
+        assert!(config.read_dword(1).is_err());
+        assert!(config.read_dword(2).is_err());
+        assert!(config.read_dword(3).is_err());
+        assert_eq!(config.read_dword(16).unwrap(), 0xddcc_bbaa);
+        assert!(config.read_dword(17).is_err());
+        assert!(config.read_dword(18).is_err());
+        assert!(config.read_dword(19).is_err());
+    }
+
+    #[test]
+    fn test_config_write() {
+        let mut config = DummyConfig {
+            registers: [0u32; 64],
+        };
+
+        // Byte writes. All byte accesses are aligned.
+        assert!(config.write_byte(0xef, 0).is_ok());
+        assert!(config.write_byte(0xbe, 1).is_ok());
+        assert!(config.write_byte(0xad, 2).is_ok());
+        assert!(config.write_byte(0xde, 3).is_ok());
+        // Assert writes are visible in the register.
+        assert_eq!(config.registers[0], 0xdead_beef);
+
+        // Word writes.
+        assert!(config.write_word(0xbeef, 4).is_ok());
+        assert!(config.write_word(0xdead, 6).is_ok());
+        // Assert writes are visible in the register.
+        assert_eq!(config.registers[1], 0xdead_beef);
+
+        // Unaligned word accesses.
+        assert!(config.write_word(0, 5).is_err());
+        assert!(config.write_word(0, 7).is_err());
+        // Assert state hasn't changed.
+        assert_eq!(config.registers[1], 0xdead_beef);
+
+        assert_eq!(config.registers[2], 0);
+        // Dword write.
+        assert!(config.write_dword(0xdead_beef, 8).is_ok());
+        // Assert write are visible in the register.
+        assert_eq!(config.registers[2], 0xdead_beef);
+
+        // Unaligned dword accesses.
+        assert!(config.write_dword(0, 9).is_err());
+        assert!(config.write_dword(0, 10).is_err());
+        assert!(config.write_dword(0, 11).is_err());
+        // Assert state hasn't changed.
+        assert_eq!(config.registers[2], 0xdead_beef);
+    }
+}


### PR DESCRIPTION
### Summary of the PR

This PR adds:
- common PCI configuration space abstractions
- PCI device configuration space abstractions
- PCI bridge constants
- Base Address Register abstractions
- high-level crate documentation

A more detailed view of the PR contents is available in the documentation part.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and follow
  [the 50/72 git commit rule](https://www.midori-global.com/blog/2018/04/02/git-50-72-rule).
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] Any newly added `unsafe` code is properly documented.
